### PR TITLE
Capitalize "Reply-To" header.

### DIFF
--- a/oulib_authorizedsender.module
+++ b/oulib_authorizedsender.module
@@ -9,6 +9,6 @@ function oulib_authorizedsender_mail_alter(&$message){
    * Set Reply-to based on From and override From so mail might actually go through
    */
   $site_email = variable_get('site_mail', '');
-  $message['headers']['Reply-to'] = $message['headers']['From'];
+  $message['headers']['Reply-To'] = $message['headers']['From'];
   $message['headers']['From']= "OU Libraries Web <".$site_email .">";
 }


### PR DESCRIPTION
It looks like this needs to be `Reply-To` rather than `Reply-to` to properly overwrite existing headers so that we don't end up with both as headers in resulting emails.